### PR TITLE
Add sbt-scalafmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: sbt compile
+    - run: sbt compile scalafmtCheckAll

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,3 @@
-version = "3.0.5"
+version = 3.3.0 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+runner.dialect = scala213 // https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
+maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/src/main/scala/free.scala
+++ b/src/main/scala/free.scala
@@ -8,7 +8,8 @@ object Main extends App {
 
   trait Monad[M[_]] {
     def pure[A](x: A): M[A]
-    def map[A, B](x: M[A])(f: A => B): M[B] = flatMap(x)(a => pure(f(a)))
+    def map[A, B](x: M[A])(f: A => B): M[B] =
+      flatMap(x)(a => pure(f(a)))
     def flatMap[A, B](x: M[A])(f: A => M[B]): M[B]
   }
 

--- a/src/main/scala/mtx.scala
+++ b/src/main/scala/mtx.scala
@@ -5,7 +5,8 @@ object Main extends App {
   trait Monad[M[_]] {
     def pure[A](x: A): M[A]
     def flatMap[A, B](x: M[A])(f: A => M[B]): M[B]
-    def map[A, B](x: M[A])(f: A => B): M[B] = flatMap(x)(a => pure(f(a)))
+    def map[A, B](x: M[A])(f: A => B): M[B] =
+      flatMap(x)(a => pure(f(a)))
   }
 
   implicit class MonadOps[M[_]: Monad, A](ma: M[A]) {
@@ -99,9 +100,13 @@ object Main extends App {
 
   def readEnv(name: String): Program[String] =
     new WriteT[ReadEnvT[ReadLnT[ID[*], *], *], String] {
-      def runOut(write: String => Unit): ReadEnvT[ReadLnT[ID[*], *], String] = {
+      def runOut(
+          write: String => Unit
+      ): ReadEnvT[ReadLnT[ID[*], *], String] = {
         new ReadEnvT[ReadLnT[ID[*], *], String] {
-          override def runEnv(env: Map[String, String]): ReadLnT[ID, String] =
+          override def runEnv(
+              env: Map[String, String]
+          ): ReadLnT[ID, String] =
             new ReadLnT[ID, String] {
               override def runIn(readLn: () => String): String = {
                 env(name)
@@ -113,9 +118,13 @@ object Main extends App {
 
   def readLn(): Program[String] =
     new WriteT[ReadEnvT[ReadLnT[ID[*], *], *], String] {
-      def runOut(write: String => Unit): ReadEnvT[ReadLnT[ID[*], *], String] = {
+      def runOut(
+          write: String => Unit
+      ): ReadEnvT[ReadLnT[ID[*], *], String] = {
         new ReadEnvT[ReadLnT[ID[*], *], String] {
-          override def runEnv(env: Map[String, String]): ReadLnT[ID, String] =
+          override def runEnv(
+              env: Map[String, String]
+          ): ReadLnT[ID, String] =
             new ReadLnT[ID, String] {
               override def runIn(readLn: () => String): String = {
                 readLn()
@@ -127,9 +136,13 @@ object Main extends App {
 
   def write(output: String): Program[Unit] =
     new WriteT[ReadEnvT[ReadLnT[ID[*], *], *], Unit] {
-      def runOut(write: String => Unit): ReadEnvT[ReadLnT[ID[*], *], Unit] = {
+      def runOut(
+          write: String => Unit
+      ): ReadEnvT[ReadLnT[ID[*], *], Unit] = {
         new ReadEnvT[ReadLnT[ID[*], *], Unit] {
-          override def runEnv(env: Map[String, String]): ReadLnT[ID, Unit] =
+          override def runEnv(
+              env: Map[String, String]
+          ): ReadLnT[ID, Unit] =
             new ReadLnT[ID, Unit] {
               override def runIn(readLn: () => String): Unit = {
                 write(output)

--- a/src/main/scala/reader.scala
+++ b/src/main/scala/reader.scala
@@ -34,26 +34,27 @@ object Main extends App {
 
   val enProgram: Reader[HasReadLn with HasWrite, Unit] =
     for {
-      _    <- write("What's your name? ")
+      _ <- write("What's your name? ")
       name <- readLn()
-      _    <- write(s"Hello, ${name}!\n")
+      _ <- write(s"Hello, ${name}!\n")
     } yield ()
 
   val esProgram: Reader[HasReadLn with HasWrite, Unit] =
     for {
-      _    <- write("¿Cómo te llamas? ")
+      _ <- write("¿Cómo te llamas? ")
       name <- readLn()
-      _    <- write(s"¡Hola, ${name}!\n")
+      _ <- write(s"¡Hola, ${name}!\n")
     } yield ()
 
   val program: Reader[HasEnv with HasReadLn with HasWrite, Unit] =
     for {
       lang <- readEnv[HasEnv with HasReadLn with HasWrite]("LANG")
-      _    <- if (lang.startsWith("es")) {
-                esProgram
-              } else {
-                enProgram
-              }
+      _ <-
+        if (lang.startsWith("es")) {
+          esProgram
+        } else {
+          enProgram
+        }
     } yield ()
 
   program.run {
@@ -78,7 +79,7 @@ object ZIO extends App {
       }
     }
 
-    trait HasReadLn {
+  trait HasReadLn {
     def readLn(): String
   }
 
@@ -102,26 +103,28 @@ object ZIO extends App {
 
   val enProgram: zio.ZIO[HasReadLn with HasWrite, Throwable, Unit] =
     for {
-      _    <- write("What's your name? ")
+      _ <- write("What's your name? ")
       name <- readLn
-      _    <- write(s"Hello, ${name}!\n")
+      _ <- write(s"Hello, ${name}!\n")
     } yield ()
 
   val esProgram: zio.ZIO[HasReadLn with HasWrite, Throwable, Unit] =
     for {
-      _    <- write("¿Cómo te llamas? ")
+      _ <- write("¿Cómo te llamas? ")
       name <- readLn
-      _    <- write(s"¡Hola, ${name}!\n")
+      _ <- write(s"¡Hola, ${name}!\n")
     } yield ()
 
-  val program: zio.ZIO[HasEnv with HasReadLn with HasWrite, Throwable, Unit] =
+  val program
+      : zio.ZIO[HasEnv with HasReadLn with HasWrite, Throwable, Unit] =
     for {
       lang <- readEnv("LANG")
-      _    <- if (lang.startsWith("es")) {
-                esProgram
-              } else {
-                enProgram
-              }
+      _ <-
+        if (lang.startsWith("es")) {
+          esProgram
+        } else {
+          enProgram
+        }
     } yield ()
 
   zio.Runtime.default.unsafeRun {
@@ -130,13 +133,11 @@ object ZIO extends App {
         new HasEnv {
           override val env: Map[String, String] = sys.env
         }
-      } ++
-      zio.ZLayer.succeed {
+      } ++ zio.ZLayer.succeed {
         new HasReadLn {
           override def readLn(): String = scala.io.StdIn.readLine()
         }
-      } ++
-      zio.ZLayer.succeed {
+      } ++ zio.ZLayer.succeed {
         new HasWrite {
           override def write(output: String): Unit = print(output)
         }

--- a/src/main/scala/tf.scala
+++ b/src/main/scala/tf.scala
@@ -4,7 +4,8 @@ object Main extends App {
 
   trait Monad[M[_]] {
     def pure[A](x: A): M[A]
-    def map[A, B](x: M[A])(f: A => B): M[B] = flatMap(x)(a => pure(f(a)))
+    def map[A, B](x: M[A])(f: A => B): M[B] =
+      flatMap(x)(a => pure(f(a)))
     def flatMap[A, B](x: M[A])(f: A => M[B]): M[B]
   }
 


### PR DESCRIPTION
This adds sbt-scalafmt, configured for Scala 2.13, and a CI step to
check whether sources have been formatted. This also applies formatting
to all sources, so that the CI check will pass.