### PR TITLE
cats-core: 2.9.0 -> 2.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,5 @@ addCompilerPlugin(
   "org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full
 )
 
-libraryDependencies += "org.typelevel" %% "cats-core" % "2.9.0"
+libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
 libraryDependencies += "dev.zio" %% "zio" % "2.0.15"


### PR DESCRIPTION
📦 Updates [org.typelevel:cats-core](https://github.com/typelevel/cats) from `2.9.0` to `2.10.0`

📜 [GitHub Release Notes](https://github.com/typelevel/cats/releases/tag/v2.10.0) - [Version Diff](https://github.com/typelevel/cats/compare/v2.9.0...v2.10.0)