### PR TITLE
zio: 2.0.16 -> 2.0.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.0.16"
+libraryDependencies += "dev.zio" %% "zio" % "2.0.17"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.16` to `2.0.17`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.0.17) - [Version Diff](https://github.com/zio/zio/compare/v2.0.16...v2.0.17)