### PR TITLE
scala: 2.13.11 -> 2.13.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 
 addCompilerPlugin(
   "org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.13.11` to `2.13.12`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.13.12) - [Version Diff](https://github.com/scala/scala/compare/v2.13.11...v2.13.12)