### PR TITLE
zio: 2.0.19 -> 2.0.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.0.19"
+libraryDependencies += "dev.zio" %% "zio" % "2.0.20"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.19` to `2.0.20`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.0.20) - [Version Diff](https://github.com/zio/zio/compare/v2.0.19...v2.0.20)