### PR TITLE
zio: 2.0.20 -> 2.0.21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.0.20"
+libraryDependencies += "dev.zio" %% "zio" % "2.0.21"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.20` to `2.0.21`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.0.21) - [Version Diff](https://github.com/zio/zio/compare/v2.0.20...v2.0.21)