### PR TITLE
zio: 2.0.21 -> 2.0.22

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.0.21"
+libraryDependencies += "dev.zio" %% "zio" % "2.0.22"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.21` to `2.0.22`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.0.22) - [Version Diff](https://github.com/zio/zio/compare/v2.0.21...v2.0.22)