### PR TITLE
zio: 2.0.22 -> 2.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.12.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.0.22"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.2"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.0.22` to `2.1.2`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.2) - [Version Diff](https://github.com/zio/zio/compare/v2.0.22...v2.1.2)