### PR TITLE
zio: 2.1.2 -> 2.1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.12.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.1.2"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.4"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.2` to `2.1.4`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/2.1.4) - [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.4) - [Version Diff](https://github.com/zio/zio/compare/v2.1.2...v2.1.4)