### PR TITLE
zio: 2.1.6 -> 2.1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.12.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.1.6"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.7"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.6` to `2.1.7`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.7) - [Version Diff](https://github.com/zio/zio/compare/v2.1.6...v2.1.7)