### PR TITLE
sbt-tpolecat: 0.5.1 -> 0.5.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.1")
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates [org.typelevel:sbt-tpolecat](https://github.com/typelevel/sbt-tpolecat) from `0.5.1` to `0.5.2`

📜 [GitHub Release Notes](https://github.com/typelevel/sbt-tpolecat/releases/tag/v0.5.2) - [Version Diff](https://github.com/typelevel/sbt-tpolecat/compare/v0.5.1...v0.5.2)