### PR TITLE
zio: 2.1.8 -> 2.1.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,4 +5,4 @@ addCompilerPlugin(
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.12.0"
-libraryDependencies += "dev.zio" %% "zio" % "2.1.8"
+libraryDependencies += "dev.zio" %% "zio" % "2.1.9"


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.8` to `2.1.9`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.9) - [Version Diff](https://github.com/zio/zio/compare/v2.1.8...v2.1.9)