### PR TITLE
scala-library: 2.13.14 -> 2.13.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.14"
+scalaVersion := "2.13.15"
 
 addCompilerPlugin(
   "org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.13.14` to `2.13.15`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.13.15) - [Version Diff](https://github.com/scala/scala/compare/v2.13.14...v2.13.15)