### PR TITLE
kind-projector: 0.13.3 -> 0.13.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 scalaVersion := "2.13.16"
 
 addCompilerPlugin(
-  "org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full
+  "org.typelevel" %% "kind-projector" % "0.13.4" cross CrossVersion.full
 )
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.13.0"


### PR DESCRIPTION
## About this PR
📦 Updates org.typelevel:kind-projector from `0.13.3` to `0.13.4`

<!-- scala-steward = {
  "Update" : {
    "ForArtifactId" : {
      "crossDependency" : [
        {
          "groupId" : "org.typelevel",
          "artifactId" : {
            "name" : "kind-projector",
            "maybeCrossName" : "kind-projector_2.13.16"
          },
          "version" : "0.13.3",
          "sbtVersion" : null,
          "scalaVersion" : null,
          "configurations" : "plugin->default(compile)"
        }
      ],
      "newerVersions" : [
        "0.13.4"
      ],
      "newerGroupId" : null,
      "newerArtifactId" : null
    }
  },
  "Labels" : [
    "library-update",
    "early-semver-minor",
    "semver-spec-patch",
    "commit-count:1"
  ]
} -->